### PR TITLE
Update view.xml on "group-tenant-and-hierarchy"

### DIFF
--- a/modules/global/src/com/haulmont/addon/sdbmt/views.xml
+++ b/modules/global/src/com/haulmont/addon/sdbmt/views.xml
@@ -50,7 +50,9 @@
             <property name="group"
                       view="_minimal"/>
             <property name="parent"
-                      view="_minimal"/>
+                      view="_minimal">
+              <property name="sysTenantId"/>
+            </property/
             <property name="sysTenantId"/>
         </property>
     </view>


### PR DESCRIPTION
Add "sysTenantId" property on "parent" property, in order to support multiple levels of group (more than 2 levels of hierarchy) when creating a new tenant. Otherwise “IllegalStateException: Cannot get unfetched attribute [sysTenantId] from detached object com.haulmont.addon.sdbmt.entity.TenantGroup” will be thrown.

![image](https://user-images.githubusercontent.com/3366240/87378594-b63c0180-c5c0-11ea-96d4-57e80346660a.png)
![image](https://user-images.githubusercontent.com/3366240/87378736-17fc6b80-c5c1-11ea-820a-bfce0d4498e5.png)
