### PR TITLE
Update view.xml on "group-tenant-and-hierarchy"

### DIFF
--- a/modules/global/src/com/haulmont/addon/sdbmt/views.xml
+++ b/modules/global/src/com/haulmont/addon/sdbmt/views.xml
@@ -50,7 +50,9 @@
             <property name="group"
                       view="_minimal"/>
             <property name="parent"
-                      view="_minimal"/>
+                      view="_minimal">
+              <property name="sysTenantId"/>
+            </property>
             <property name="sysTenantId"/>
         </property>
     </view>


### PR DESCRIPTION
Add "sysTenantId" property on "parent" property, in order to support multiple levels of group (more than 2 levels of hierarchy) when creating a new tenant. Otherwise “IllegalStateException: Cannot get unfetched attribute [sysTenantId] from detached object com.haulmont.addon.sdbmt.entity.TenantGroup” will be thrown.

![image](https://user-images.githubusercontent.com/3366240/87380010-2304cb00-c5c4-11ea-8a55-6620c36b9e64.png)
![image](https://user-images.githubusercontent.com/3366240/87380068-44fe4d80-c5c4-11ea-96d6-9c2a6661a593.png)
![image](https://user-images.githubusercontent.com/3366240/87380025-2bf59c80-c5c4-11ea-9443-4faa48af3c5c.png)
